### PR TITLE
[fix] Fix invalid @Security annotation

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -40,7 +40,7 @@ use Throwable;
  *     path="/user",
  *  )
  *
- * ecurity("is_granted('IS_AUTHENTICATED_FULLY')")
+ * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
  *
  * @SWG\Tag(name="User Management")
  *
@@ -60,6 +60,7 @@ class UserController extends Controller
     use Actions\Root\PatchAction;
     use Actions\Root\UpdateAction;
     use Methods\DeleteMethod;
+
     /**
      * Method + Form type class names (key + value)
      *


### PR DESCRIPTION
I think there is an accidental change in `@Security` annotation in [this commit](https://github.com/tarlepp/symfony-flex-backend/commit/c7df579738082ce186f2fa68d349cd29c023635b#diff-2e6355de36175249110ad2b48562407aR43) which should be fixed?