### PR TITLE
Feat/RequestLogger improvements

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use function in_array;
 
 /**
  * Class RequestSubscriber
@@ -94,11 +95,12 @@ class RequestSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $path = $request->getPathInfo();
 
-        // We don't want to log /healthz , /version , /_profiler* and OPTIONS requests
-        if ($path === '/healthz'
-            || $path === '/version'
-            || strpos($path, '/_profiler') !== false
-            || $request->getRealMethod() === 'OPTIONS'
+        static $ignorePaths = ['', '/', '/healthz', '/version'];
+
+        // We don't want to log ignored paths, /_profiler* -path and OPTIONS requests
+        if (in_array($path, $ignorePaths, true)
+            || (strpos($path, '/_profiler') !== false)
+            || ($request->getRealMethod() === 'OPTIONS')
         ) {
             return;
         }

--- a/tests/Integration/EventSubscriber/RequestSubscriberTest.php
+++ b/tests/Integration/EventSubscriber/RequestSubscriberTest.php
@@ -15,6 +15,7 @@ use App\Repository\UserRepository;
 use App\Security\ApiKeyUser;
 use App\Security\SecurityUser;
 use App\Utils\RequestLogger;
+use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -41,7 +42,7 @@ class RequestSubscriberTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $request = new Request();
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/foobar']);
         $response = new Response();
 
         $event = new ResponseEvent(static::$kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -90,7 +91,7 @@ class RequestSubscriberTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $request = new Request();
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/foobar']);
         $response = new Response();
 
         $event = new ResponseEvent(static::$kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -144,7 +145,7 @@ class RequestSubscriberTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $request = new Request();
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/foobar']);
         $response = new Response();
 
         $event = new ResponseEvent(static::$kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -196,7 +197,7 @@ class RequestSubscriberTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
+        $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'OPTIONS', 'REQUEST_URI' => '/foobar']);
         $response = new Response();
 
         $event = new ResponseEvent(static::$kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -223,13 +224,19 @@ class RequestSubscriberTest extends KernelTestCase
     }
 
     /**
+     * @dataProvider dataProviderTestThatLoggerServiceIsNotCalledWhenUsingWhitelistedUrl
+     *
+     * @param string $url
+     *
+     * @testdox Test that `Logger` service is not called when making request to `$url` url.
+     *
      * @throws Throwable
      */
-    public function testThatLoggerServiceIsNotCalledIfHealthzRequest(): void
+    public function testThatLoggerServiceIsNotCalledWhenUsingWhitelistedUrl(string $url): void
     {
         static::bootKernel();
 
-        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/healthz']);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $url]);
         $response = new Response();
 
         $event = new ResponseEvent(static::$kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -253,5 +260,16 @@ class RequestSubscriberTest extends KernelTestCase
 
         $subscriber = new RequestSubscriber($requestLogger, $userRepository, $tokenStorage, $logger);
         $subscriber->onKernelResponse($event);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function dataProviderTestThatLoggerServiceIsNotCalledWhenUsingWhitelistedUrl(): Generator
+    {
+        yield [''];
+        yield ['/'];
+        yield ['/healthz'];
+        yield ['/version'];
     }
 }


### PR DESCRIPTION
This PR adds root route `` and `/` to ignore list within `RequestLogger`, there isn't point to collect log from that route at all. Another change is that PR adds missing `robots.txt` file to `public` HTML root directory, so that we don't get tons of `404` requests to our log - just because there is multiple search engines that tries to access this `robots.txt` file.