### PR TITLE
feat: Application specified `ValidatorException`

### DIFF
--- a/phpinsights.php
+++ b/phpinsights.php
@@ -56,6 +56,7 @@ return [
         NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff::class,
         ObjectCalisthenics\Sniffs\Classes\ForbiddenPublicPropertySniff::class,
         ObjectCalisthenics\Sniffs\NamingConventions\NoSetterSniff::class,
+        SlevomatCodingStandard\Sniffs\Classes\SuperfluousExceptionNamingSniff::class,
         SlevomatCodingStandard\Sniffs\Classes\SuperfluousInterfaceNamingSniff::class,
         SlevomatCodingStandard\Sniffs\Classes\SuperfluousTraitNamingSniff::class,
         SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff::class,

--- a/src/EventSubscriber/ExceptionSubscriber.php
+++ b/src/EventSubscriber/ExceptionSubscriber.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 
 namespace App\EventSubscriber;
 
+use App\Exception\ValidatorException;
 use App\Utils\JSON;
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\ORMException;
@@ -208,6 +209,8 @@ class ExceptionSubscriber implements EventSubscriberInterface
             $statusCode = $isUser ? Response::HTTP_FORBIDDEN : Response::HTTP_UNAUTHORIZED;
         } elseif ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
+        } elseif ($exception instanceof ValidatorException) {
+            $statusCode = Response::HTTP_BAD_REQUEST;
         }
 
         return $statusCode;

--- a/src/Exception/ValidatorException.php
+++ b/src/Exception/ValidatorException.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types = 1);
+/**
+ * /src/Exception/ValidatorException.php
+ *
+ * @author TLe, Tarmo Leppänen <tarmo.leppanen@protacon.com>
+ */
+
+namespace App\Exception;
+
+use App\Utils\JSON;
+use JsonException;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Exception\ValidatorException as BaseValidatorException;
+use function str_replace;
+
+/**
+ * Class ValidatorException
+ *
+ * @package App\Exception
+ * @author  TLe, Tarmo Leppänen <tarmo.leppanen@protacon.com>
+ */
+class ValidatorException extends BaseValidatorException
+{
+    /**
+     * ValidatorException constructor.
+     *
+     * @param string                           $target
+     * @param ConstraintViolationListInterface $errors
+     *
+     * @throws JsonException
+     */
+    public function __construct(string $target, ConstraintViolationListInterface $errors)
+    {
+        $output = [];
+
+        /** @var ConstraintViolationInterface $error */
+        foreach ($errors as $error) {
+            $output[] = [
+                'message' => $error->getMessage(),
+                'propertyPath' => $error->getPropertyPath(),
+                'target' => str_replace('\\', '.', $target),
+                'code' => $error->getCode(),
+            ];
+        }
+
+        parent::__construct(JSON::encode($output));
+    }
+}

--- a/src/Rest/Traits/RestResourceBaseMethods.php
+++ b/src/Rest/Traits/RestResourceBaseMethods.php
@@ -10,17 +10,13 @@ namespace App\Rest\Traits;
 
 use App\DTO\RestDtoInterface;
 use App\Entity\Interfaces\EntityInterface;
+use App\Exception\ValidatorException;
 use App\Repository\Interfaces\BaseRepositoryInterface;
-use App\Utils\JSON;
-use JsonException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
-use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Throwable;
 use function get_class;
-use function str_replace;
 
 /**
  * Trait RestResourceBaseMethods
@@ -456,7 +452,7 @@ trait RestResourceBaseMethods
 
         // Oh noes, we have some errors
         if ($errors !== null && $errors->count() > 0) {
-            $this->createValidatorException($errors, get_class($dto));
+            throw new ValidatorException(get_class($dto), $errors);
         }
     }
 
@@ -474,7 +470,7 @@ trait RestResourceBaseMethods
 
         // Oh noes, we have some errors
         if ($errors !== null && $errors->count() > 0) {
-            $this->createValidatorException($errors, get_class($entity));
+            throw new ValidatorException(get_class($entity), $errors);
         }
     }
 
@@ -489,29 +485,6 @@ trait RestResourceBaseMethods
         $entityClass = $this->getRepository()->getEntityName();
 
         return new $entityClass();
-    }
-
-    /**
-     * @param ConstraintViolationListInterface $errors
-     * @param string                           $target
-     *
-     * @throws JsonException
-     */
-    private function createValidatorException(ConstraintViolationListInterface $errors, string $target): void
-    {
-        $output = [];
-
-        /** @var ConstraintViolationInterface $error */
-        foreach ($errors as $error) {
-            $output[] = [
-                'message' => $error->getMessage(),
-                'propertyPath' => $error->getPropertyPath(),
-                'target' => str_replace('\\', '.', $target),
-                'code' => $error->getCode(),
-            ];
-        }
-
-        throw new ValidatorException(JSON::encode($output));
     }
 
     /**


### PR DESCRIPTION
This PR adds new application specified `ValidatorException` that can be used to convert Symfony `ValidatorInterface` errors to an exception. This will clean up base `RestResource` logic so that this same exception can be used anywhere else in application context to make "proper" validator exception response to browser.