### PR TITLE
Refactor: Fix deprecation notices that was introduced with Symfony 5.1

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 
 set_time_limit(0);
@@ -15,8 +16,8 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) === false) {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-if (!class_exists(Application::class)) {
-    throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
+if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
 }
 
 $input = new ArgvInput();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,29 +13,30 @@ declare(strict_types = 1);
 use App\Utils\JSON;
 use Symfony\Component\Dotenv\Dotenv;
 
-$environmentFile = (string)\getenv('ENVIRONMENT_FILE');
-$readableChannel = (string)\getenv('ENV_TEST_CHANNEL_READABLE');
+$environmentFile = (string)getenv('ENVIRONMENT_FILE');
+$readableChannel = (string)getenv('ENV_TEST_CHANNEL_READABLE');
 
 // Application is started against 'fastest' library, so we need to override database name manually
-if (\strlen($readableChannel) > 0) {
-    // Parse current '.env.test' file
-    $variables = (new Dotenv(false))->parse(\file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . $environmentFile));
+if (strlen($readableChannel) > 0) {
+    // Parse current environment file - most likely '.env.test' file because `$readableChannel` exists
+    $variables = (new Dotenv())->parse(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . $environmentFile));
 
+    /** @noinspection PhpUnhandledExceptionInspection */
     $applicationConfig = JSON::decode(file_get_contents($variables['APPLICATION_CONFIG']), true);
 
     // Specify new database name for current test env
     $databaseName = $applicationConfig['DATABASE_NAME'] . '_' . $readableChannel;
 
     // Replace DATABASE_URL variable with proper database name
-    $databaseUrl = \str_replace(
+    $databaseUrl = str_replace(
         '/' . $applicationConfig['DATABASE_NAME'] . '?',
         '/' . $databaseName . '?',
         $applicationConfig['DATABASE_URL']
     );
 
     // And finally populate new variables to current environment
-    \putenv('DATABASE_NAME=' . $databaseName);
-    \putenv('DATABASE_URL=' . $databaseUrl);
+    putenv('DATABASE_NAME=' . $databaseName);
+    putenv('DATABASE_URL=' . $databaseUrl);
 }
 
 require __DIR__ . '/config/bootstrap.php';

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -18,11 +18,13 @@ if (class_exists(FastestEnvironment::class)) {
 // Ensure that current working directory is project root - this is needed to make relative paths to working properly
 chdir(dirname(__DIR__));
 
+$localPhpEnvFile = dirname(__DIR__) . '/.env.local.php';
+
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 /** @noinspection PhpIncludeInspection */
 /** @noinspection UsingInclusionReturnValueInspection */
-if (is_array($env = include dirname(__DIR__) . '/.env.local.php')
+if (is_readable($localPhpEnvFile) && is_array($env = include $localPhpEnvFile)
     && ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV'] ?? null) === ($env['APP_ENV'] ?? null)
 ) {
     foreach ($env as $k => $v) {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -6,6 +6,10 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+if (!class_exists(Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/dotenv" as Composer dependencies.');
+}
+
 // Set fastest environment
 if (class_exists(FastestEnvironment::class)) {
     FastestEnvironment::setFromRequest();
@@ -16,22 +20,18 @@ chdir(dirname(__DIR__));
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-/** @noinspection UsingInclusionReturnValueInspection */
 /** @noinspection PhpIncludeInspection */
-if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')
+/** @noinspection UsingInclusionReturnValueInspection */
+if (is_array($env = include dirname(__DIR__) . '/.env.local.php')
     && ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV'] ?? null) === ($env['APP_ENV'] ?? null)
 ) {
     foreach ($env as $k => $v) {
         $_ENV[$k] ??= (isset($_SERVER[$k]) && strncmp($k, 'HTTP_', 5) !== 0 ? $_SERVER[$k] : $v);
     }
-} elseif (class_exists(Dotenv::class)) {
-    // load all the .env files
-    (new Dotenv(false))->loadEnv(dirname(__DIR__) . '/.env');
-} else {
-    throw new RuntimeException(
-        'Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.'
-    );
 }
+
+// load all the .env files
+(new Dotenv())->loadEnv(dirname(__DIR__) . '/.env');
 
 /** @noinspection AdditionOperationOnArraysInspection */
 $_SERVER += $_ENV;

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,8 +12,6 @@
 
         <ignoreFiles>
             <directory name="vendor" />
-
-            <file name="src/Kernel.php" />
         </ignoreFiles>
     </projectFiles>
 

--- a/src/AutoMapper/RestRequestMapper.php
+++ b/src/AutoMapper/RestRequestMapper.php
@@ -40,9 +40,9 @@ abstract class RestRequestMapper implements MapperInterface
     /**
      * {@inheritdoc}
      *
-     * @param array|object            $source
-     * @param string                  $targetClass
-     * @param array|array<int, mixed> $context
+     * @param array|object      $source
+     * @param string            $targetClass
+     * @param array<int, mixed> $context
      *
      * @return RestDtoInterface
      */
@@ -57,9 +57,9 @@ abstract class RestRequestMapper implements MapperInterface
     /**
      * {@inheritdoc}
      *
-     * @param array|object            $source
-     * @param object                  $destination
-     * @param array|array<int, mixed> $context
+     * @param array|object      $source
+     * @param object            $destination
+     * @param array<int, mixed> $context
      *
      * @return RestDtoInterface
      */
@@ -117,7 +117,7 @@ abstract class RestRequestMapper implements MapperInterface
             $transformer = 'transform' . ucfirst($property);
 
             /** @var int|string|array|null $value */
-            $value = $request->request->get($property);
+            $value = $request->get($property);
 
             if (method_exists($this, $transformer)) {
                 /** @var int|string|object|array|null $value */

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -22,7 +22,7 @@ class Kernel extends BaseKernel
     use MicroKernelTrait;
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected function configureContainer(ContainerConfigurator $container): void
     {
@@ -33,7 +33,7 @@ class Kernel extends BaseKernel
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected function configureRoutes(RoutingConfigurator $routes): void
     {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -2,88 +2,43 @@
 declare(strict_types = 1);
 /**
  * /src/Kernel.php
- *
- * @author TLe, Tarmo Leppänen <tarmo.leppanen@protacon.com>
  */
 
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\Config\Resource\FileResource;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
-use Throwable;
-use function dirname;
-use const PHP_VERSION_ID;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 /**
  * Class Kernel
  *
  * @package App
- * @author  TLe, Tarmo Leppänen <tarmo.leppanen@protacon.com>
  */
 class Kernel extends BaseKernel
 {
+    // Traits
     use MicroKernelTrait;
 
-    private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
-
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
-    public function registerBundles(): iterable
+    protected function configureContainer(ContainerConfigurator $container): void
     {
-        /** @noinspection PhpIncludeInspection */
-        /** @noinspection UsingInclusionReturnValueInspection */
-        $contents = require $this->getProjectDir() . '/config/bundles.php';
-
-        foreach ($contents as $class => $envs) {
-            if ($envs[$this->environment] ?? $envs['all'] ?? false) {
-                yield new $class();
-            }
-        }
-    }
-
-    /** @noinspection PhpMissingParentCallCommonInspection */
-    /**
-     * {@inheritdoc}
-     */
-    public function getProjectDir(): string
-    {
-        return dirname(__DIR__);
+        $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/' . $this->environment . '/*.yaml');
+        $container->import('../config/{services}.yaml');
+        $container->import('../config/{services}_' . $this->environment . '.yaml');
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @throws Throwable
+     * @inheritDoc
      */
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    protected function configureRoutes(RoutingConfigurator $routes): void
     {
-        $container->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
-        $container->setParameter('container.dumper.inline_class_loader', PHP_VERSION_ID < 70400 || $this->debug);
-        $container->setParameter('container.dumper.inline_factories', true);
-        $confDir = $this->getProjectDir() . '/config';
-
-        $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws Throwable
-     */
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
-    {
-        $confDir = $this->getProjectDir() . '/config';
-
-        $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
+        $routes->import('../config/{routes}/' . $this->environment . '/*.yaml');
+        $routes->import('../config/{routes}/*.yaml');
+        $routes->import('../config/{routes}.yaml');
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -22,7 +22,7 @@ class Kernel extends BaseKernel
     use MicroKernelTrait;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configureContainer(ContainerConfigurator $container): void
     {
@@ -33,7 +33,7 @@ class Kernel extends BaseKernel
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configureRoutes(RoutingConfigurator $routes): void
     {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -18,7 +18,6 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
  */
 class Kernel extends BaseKernel
 {
-    // Traits
     use MicroKernelTrait;
 
     /**

--- a/src/Utils/Tests/Auth.php
+++ b/src/Utils/Tests/Auth.php
@@ -11,8 +11,8 @@ namespace App\Utils\Tests;
 use App\Utils\JSON;
 use JsonException;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Throwable;
 use UnexpectedValueException;
 use function array_key_exists;
@@ -35,16 +35,16 @@ use function sys_get_temp_dir;
  */
 class Auth
 {
-    private ContainerInterface $testContainer;
+    private KernelInterface $kernel;
 
     /**
      * Auth constructor.
      *
-     * @param ContainerInterface $container
+     * @param KernelInterface $kernel
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(KernelInterface $kernel)
     {
-        $this->testContainer = $container;
+        $this->kernel = $kernel;
     }
 
     /**
@@ -142,7 +142,7 @@ class Auth
         if (!array_key_exists($hash, $cache)) {
             // Get client
             /** @var KernelBrowser $client */
-            $client = $this->testContainer->get('test.client');
+            $client = $this->kernel->getContainer()->get('test.client');
 
             // Create request to make login using given credentials
             $client->request(

--- a/tests/Integration/Entity/LogRequestTest.php
+++ b/tests/Integration/Entity/LogRequestTest.php
@@ -114,7 +114,7 @@ class LogRequestTest extends EntityTestCase
         $logRequest = new LogRequest(
             [],
             Request::create(''),
-            Response::create('abcdefgh'),
+            new Response('abcdefgh'),
             new User(),
             new ApiKey()
         );
@@ -173,7 +173,7 @@ class LogRequestTest extends EntityTestCase
         $request = Request::create('');
         $request->headers->replace($headers->getArrayCopy());
 
-        $logRequest = new LogRequest($properties->getArrayCopy(), $request, Response::create());
+        $logRequest = new LogRequest($properties->getArrayCopy(), $request, new Response());
 
         static::assertSame($expected->getArrayCopy(), $logRequest->getHeaders());
     }
@@ -197,7 +197,7 @@ class LogRequestTest extends EntityTestCase
         $request = Request::create('', 'POST');
         $request->request->replace($parameters->getArrayCopy());
 
-        $logRequest = new LogRequest($properties->getArrayCopy(), $request, Response::create());
+        $logRequest = new LogRequest($properties->getArrayCopy(), $request, new Response());
 
         static::assertSame($expected->getArrayCopy(), $logRequest->getParameters());
     }
@@ -214,7 +214,7 @@ class LogRequestTest extends EntityTestCase
      */
     public function testThatDetermineParametersWorksLikeExpected(string $content, StringableArrayObject $expected): void
     {
-        $logRequest = new LogRequest([], Request::create(''), Response::create());
+        $logRequest = new LogRequest([], Request::create(''), new Response());
 
         $request = Request::create('', 'GET', [], [], [], [], $content);
 

--- a/tests/Integration/Rest/Traits/Methods/CountMethodTest.php
+++ b/tests/Integration/Rest/Traits/Methods/CountMethodTest.php
@@ -162,7 +162,7 @@ class CountMethodTest extends KernelTestCase
 
         // Create request and response
         $request = Request::create('/count');
-        $response = Response::create('123');
+        $response = new Response('123');
 
         $resource
             ->expects(static::once())

--- a/tests/Integration/Rest/Traits/Methods/FindMethodTest.php
+++ b/tests/Integration/Rest/Traits/Methods/FindMethodTest.php
@@ -161,7 +161,7 @@ class FindMethodTest extends KernelTestCase
 
         // Create request and response
         $request = Request::create('/');
-        $response = Response::create('[]');
+        $response = new Response('[]');
 
         $resource
             ->expects(static::once())

--- a/tests/Integration/Rest/Traits/Methods/IdsMethodTest.php
+++ b/tests/Integration/Rest/Traits/Methods/IdsMethodTest.php
@@ -161,7 +161,7 @@ class IdsMethodTest extends KernelTestCase
 
         // Create request and response
         $request = Request::create('/');
-        $response = Response::create('[]');
+        $response = new Response('[]');
 
         $resource
             ->expects(static::once())


### PR DESCRIPTION
There is still couple of those left, but those are coming from 3rd party libraries and atm we need just to wait them to release new versions of those packages.