### PR TITLE
Chore(env)/Development environment startup fix

### DIFF
--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -25,7 +25,7 @@ else
     HOST="docker.for.mac.localhost"
 fi
 
-sed -i "s/xdebug\.client_host \=.*/xdebug\.client_host\=$HOST/g" /usr/local/etc/php/php.ini
+sed -i "s/xdebug\.client_host \=.*/xdebug\.client_host\ = $HOST/g" /usr/local/etc/php/php.ini
 
 DOCKER_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
 

--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -21,7 +21,7 @@ if [[ -z "${DOCKER_WITH_MAC}" ]]; then
     # Not Mac, so determine actual docker container IP address
     HOST=$(/sbin/ip route|awk '/default/ { print $3 }')
 else
-    # Otherwise use special value, which works wit Mac
+    # Otherwise use special value, which works with Mac
     HOST="docker.for.mac.localhost"
 fi
 


### PR DESCRIPTION
Fix for sed command, so that this works _if_ docker container IP address changes after _first_ start. Thanks to @pmikmaj to pointing this out.