### PR TITLE
Refactor/Changed `loadUserByUsername` to `loadUserByIdentifier` in user provider factories

### DIFF
--- a/src/EventSubscriber/AuthenticationFailureSubscriber.php
+++ b/src/EventSubscriber/AuthenticationFailureSubscriber.php
@@ -61,7 +61,7 @@ class AuthenticationFailureSubscriber implements EventSubscriberInterface
             /** @var string $username */
             $username = $token->getUser();
 
-            $this->loginLogger->setUser($this->userRepository->loadUserByUsername($username, false));
+            $this->loginLogger->setUser($this->userRepository->loadUserByIdentifier($username, false));
         }
 
         $this->loginLogger->process(EnumLogLoginType::TYPE_FAILURE);

--- a/src/EventSubscriber/AuthenticationSuccessSubscriber.php
+++ b/src/EventSubscriber/AuthenticationSuccessSubscriber.php
@@ -54,7 +54,7 @@ class AuthenticationSuccessSubscriber implements EventSubscriberInterface
     public function onAuthenticationSuccess(AuthenticationSuccessEvent $event): void
     {
         $this->loginLogger
-            ->setUser($this->userRepository->loadUserByUsername($event->getUser()->getUserIdentifier(), true))
+            ->setUser($this->userRepository->loadUserByIdentifier($event->getUser()->getUserIdentifier(), true))
             ->process(EnumLogLoginType::TYPE_SUCCESS);
     }
 }

--- a/src/EventSubscriber/LockedUserSubscriber.php
+++ b/src/EventSubscriber/LockedUserSubscriber.php
@@ -96,9 +96,9 @@ class LockedUserSubscriber implements EventSubscriberInterface
     private function getUser(string | object $user): ?User
     {
         return match (true) {
-            is_string($user) => $this->userRepository->loadUserByUsername($user, false),
+            is_string($user) => $this->userRepository->loadUserByIdentifier($user, false),
             $user instanceof SecurityUser =>
-                $this->userRepository->loadUserByUsername($user->getUserIdentifier(), true),
+                $this->userRepository->loadUserByIdentifier($user->getUserIdentifier(), true),
             default => null,
         };
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -89,7 +89,7 @@ class UserRepository extends BaseRepository
      *
      * @throws NonUniqueResultException
      */
-    public function loadUserByUsername(string $username, bool $uuid): ?Entity
+    public function loadUserByIdentifier(string $username, bool $uuid): ?Entity
     {
         /** @var array<string, Entity|null> $cache */
         static $cache = [];

--- a/src/Security/ApiKeyUser.php
+++ b/src/Security/ApiKeyUser.php
@@ -10,6 +10,7 @@ namespace App\Security;
 
 use App\Entity\ApiKey;
 use App\Security\Interfaces\ApiKeyUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
 use function array_merge;
 use function array_unique;
@@ -20,15 +21,15 @@ use function array_unique;
  * @package App\Security
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
-class ApiKeyUser implements ApiKeyUserInterface
+class ApiKeyUser implements ApiKeyUserInterface, UserInterface
 {
     /**
      * @Groups({
      *      "ApiKeyUser",
-     *      "ApiKeyUser.apiKey",
+     *      "ApiKeyUser.identifier",
      *  })
      */
-    private string $username;
+    private string $identifier;
 
     /**
      * @Groups({
@@ -53,7 +54,7 @@ class ApiKeyUser implements ApiKeyUserInterface
     public function __construct(ApiKey $apiKey, array $roles)
     {
         $this->apiKey = $apiKey;
-        $this->username = $this->apiKey->getToken();
+        $this->identifier = $this->apiKey->getToken();
         $this->roles = array_unique(array_merge($roles, [RolesService::ROLE_API]));
     }
 
@@ -99,7 +100,7 @@ class ApiKeyUser implements ApiKeyUserInterface
      */
     public function getUserIdentifier(): string
     {
-        return $this->username;
+        return $this->identifier;
     }
 
     /**
@@ -112,7 +113,7 @@ class ApiKeyUser implements ApiKeyUserInterface
     }
 
     /**
-     * @todo Remove this when this `getUsername` is removed from main interface (Symfony 6.0)
+     * @todo Remove this method when Symfony 6.0.0 is released
      *
      * {@inheritdoc}
      *

--- a/src/Security/Interfaces/ApiKeyUserInterface.php
+++ b/src/Security/Interfaces/ApiKeyUserInterface.php
@@ -9,7 +9,6 @@ declare(strict_types = 1);
 namespace App\Security\Interfaces;
 
 use App\Entity\ApiKey;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Interface ApiKeyUserInterface
@@ -17,7 +16,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @package App\Security
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
-interface ApiKeyUserInterface extends UserInterface
+interface ApiKeyUserInterface
 {
     /**
      * ApiKeyUser constructor.

--- a/src/Security/Interfaces/ApiKeyUserProviderInterface.php
+++ b/src/Security/Interfaces/ApiKeyUserProviderInterface.php
@@ -11,7 +11,6 @@ namespace App\Security\Interfaces;
 use App\Entity\ApiKey;
 use App\Repository\ApiKeyRepository;
 use App\Security\RolesService;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * Interface ApiKeyUserProviderInterface
@@ -19,7 +18,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  * @package App\Security\Provider
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
-interface ApiKeyUserProviderInterface extends UserProviderInterface
+interface ApiKeyUserProviderInterface
 {
     public function __construct(ApiKeyRepository $apiKeyRepository, RolesService $rolesService);
 

--- a/src/Security/Provider/ApiKeyUserProvider.php
+++ b/src/Security/Provider/ApiKeyUserProvider.php
@@ -11,12 +11,12 @@ namespace App\Security\Provider;
 use App\Entity\ApiKey;
 use App\Repository\ApiKeyRepository;
 use App\Security\ApiKeyUser;
-use App\Security\Interfaces\ApiKeyUserInterface;
 use App\Security\Interfaces\ApiKeyUserProviderInterface;
 use App\Security\RolesService;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * Class ApiKeyUserProvider
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @package App\Security\Provider
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
-class ApiKeyUserProvider implements ApiKeyUserProviderInterface
+class ApiKeyUserProvider implements ApiKeyUserProviderInterface, UserProviderInterface
 {
     public function __construct(
         private ApiKeyRepository $apiKeyRepository,
@@ -32,14 +32,14 @@ class ApiKeyUserProvider implements ApiKeyUserProviderInterface
     ) {
     }
 
-    public function getApiKeyForToken(string $token): ?ApiKey
+    public function supportsClass(string $class): bool
     {
-        return $this->apiKeyRepository->findOneBy(['token' => $token]);
+        return $class === ApiKeyUser::class;
     }
 
-    public function loadUserByUsername(string $username): ApiKeyUserInterface
+    public function loadUserByIdentifier(string $identifier): ApiKeyUser
     {
-        $apiKey = $this->getApiKeyForToken($username);
+        $apiKey = $this->getApiKeyForToken($identifier);
 
         if ($apiKey === null) {
             throw new UserNotFoundException('API key is not valid');
@@ -53,8 +53,18 @@ class ApiKeyUserProvider implements ApiKeyUserProviderInterface
         throw new UnsupportedUserException('API key cannot refresh user');
     }
 
-    public function supportsClass(string $class): bool
+    public function getApiKeyForToken(string $token): ?ApiKey
     {
-        return $class === ApiKeyUser::class;
+        return $this->apiKeyRepository->findOneBy(['token' => $token]);
+    }
+
+    /**
+     * @todo Remove this method when Symfony 6.0.0 is released
+     *
+     * @codeCoverageIgnore
+     */
+    public function loadUserByUsername(string $username): ApiKeyUser
+    {
+        return $this->loadUserByIdentifier($username);
     }
 }

--- a/src/Security/Provider/SecurityUserFactory.php
+++ b/src/Security/Provider/SecurityUserFactory.php
@@ -34,28 +34,28 @@ class SecurityUserFactory implements UserProviderInterface
     ) {
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws Throwable
-     */
-    public function loadUserByUsername(string $username): UserInterface
-    {
-        $user = $this->userRepository->loadUserByUsername(
-            $username,
-            (bool)preg_match('#' . $this->uuidV1Regex . '#', $username)
-        );
-
-        if (!($user instanceof User)) {
-            throw new UserNotFoundException(sprintf('User not found for UUID: "%s".', $username));
-        }
-
-        return new SecurityUser($user, $this->rolesService->getInheritedRoles($user->getRoles()));
-    }
-
     public function supportsClass(string $class): bool
     {
         return $class === SecurityUser::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Throwable
+     */
+    public function loadUserByIdentifier(string $identifier): SecurityUser
+    {
+        $user = $this->userRepository->loadUserByIdentifier(
+            $identifier,
+            (bool)preg_match('#' . $this->uuidV1Regex . '#', $identifier)
+        );
+
+        if (!($user instanceof User)) {
+            throw new UserNotFoundException(sprintf('User not found for UUID: "%s".', $identifier));
+        }
+
+        return new SecurityUser($user, $this->rolesService->getInheritedRoles($user->getRoles()));
     }
 
     /**
@@ -74,5 +74,19 @@ class SecurityUserFactory implements UserProviderInterface
         }
 
         return new SecurityUser($userEntity, $this->rolesService->getInheritedRoles($userEntity->getRoles()));
+    }
+
+    /**
+     * @todo Remove this method when Symfony 6.0.0 is released
+     *
+     * {@inheritDoc}
+     *
+     * @throws Throwable
+     *
+     * @codeCoverageIgnore
+     */
+    public function loadUserByUsername(string $username): SecurityUser
+    {
+        return $this->loadUserByIdentifier($username);
     }
 }

--- a/src/Security/SecurityUser.php
+++ b/src/Security/SecurityUser.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class SecurityUser implements UserInterface, PasswordAuthenticatedUserInterface
 {
-    private string $username;
+    private string $identifier;
     private string | null $password;
     private string $language;
     private string $locale;
@@ -38,7 +38,7 @@ class SecurityUser implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function __construct(User $user, array $roles = [])
     {
-        $this->username = $user->getId();
+        $this->identifier = $user->getId();
         $this->password = $user->getPassword();
         $this->language = $user->getLanguage();
         $this->locale = $user->getLocale();
@@ -83,7 +83,7 @@ class SecurityUser implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function getUserIdentifier(): string
     {
-        return $this->username;
+        return $this->identifier;
     }
 
     public function getLanguage(): string
@@ -111,7 +111,7 @@ class SecurityUser implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @todo Remove this when this `getUsername` is removed from main interface (Symfony 6.0)
+     * @todo Remove this method when Symfony 6.0.0 is released
      *
      * {@inheritdoc}
      *

--- a/src/Security/UserTypeIdentification.php
+++ b/src/Security/UserTypeIdentification.php
@@ -50,7 +50,7 @@ class UserTypeIdentification
     {
         $user = $this->getSecurityUser();
 
-        return $user === null ? null : $this->userRepository->loadUserByUsername($user->getUserIdentifier(), true);
+        return $user === null ? null : $this->userRepository->loadUserByIdentifier($user->getUserIdentifier(), true);
     }
 
     /**

--- a/tests/Functional/ArgumentResolver/LoggedInUserValueResolverTest.php
+++ b/tests/Functional/ArgumentResolver/LoggedInUserValueResolverTest.php
@@ -55,7 +55,7 @@ class LoggedInUserValueResolverTest extends KernelTestCase
     {
         $repository = $this->getRepository();
 
-        $user = $repository->loadUserByUsername($username, false);
+        $user = $repository->loadUserByIdentifier($username, false);
 
         static::assertNotNull($user);
 
@@ -87,7 +87,7 @@ class LoggedInUserValueResolverTest extends KernelTestCase
     {
         $repository = $this->getRepository();
 
-        $user = $repository->loadUserByUsername($username, false);
+        $user = $repository->loadUserByIdentifier($username, false);
 
         static::assertNotNull($user);
 

--- a/tests/Functional/Security/Provider/ApiKeyUserProviderTest.php
+++ b/tests/Functional/Security/Provider/ApiKeyUserProviderTest.php
@@ -87,27 +87,27 @@ class ApiKeyUserProviderTest extends KernelTestCase
     /**
      * @throws Throwable
      */
-    public function testThatLoadUserByUsernameThrowsAnExceptionWithInvalidGuid(): void
+    public function testThatLoadUserByIdentifierThrowsAnExceptionWithInvalidGuid(): void
     {
         $this->expectException(UserNotFoundException::class);
         $this->expectExceptionMessage('API key is not valid');
 
-        $this->getApiKeyUserProvider()->loadUserByUsername((string)time());
+        $this->getApiKeyUserProvider()->loadUserByIdentifier((string)time());
     }
 
     /**
-     * @dataProvider dataProviderTestThatLoadUserByUsernameWorksAsExpected
+     * @dataProvider dataProviderTestThatLoadUserByIdentifierWorksAsExpected
      *
      * @phpstan-param StringableArrayObject<array<int, string>> $roles
      * @psalm-param StringableArrayObject $roles
      *
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByUsername` returns `ApiKeyUser` with `$roles` roles when using `$token` as an input.
+     * @testdox Test that `loadUserByIdentifier` returns `ApiKeyUser` with `$roles` roles when using `$token` input
      */
-    public function testThatLoadUserByUsernameWorksAsExpected(string $token, StringableArrayObject $roles): void
+    public function testThatLoadUserByIdentifierWorksAsExpected(string $token, StringableArrayObject $roles): void
     {
-        $apiKeyUser = $this->getApiKeyUserProvider()->loadUserByUsername($token);
+        $apiKeyUser = $this->getApiKeyUserProvider()->loadUserByIdentifier($token);
 
         static::assertInstanceOf(ApiKeyUser::class, $apiKeyUser);
         static::assertSame($roles->getArrayCopy(), $apiKeyUser->getApiKey()->getRoles());
@@ -152,7 +152,7 @@ class ApiKeyUserProviderTest extends KernelTestCase
     /**
      * @return array<int, array{0: string, 1: StringableArrayObject}>
      */
-    public function dataProviderTestThatLoadUserByUsernameWorksAsExpected(): array
+    public function dataProviderTestThatLoadUserByIdentifierWorksAsExpected(): array
     {
         /** @var ManagerRegistry $managerRegistry */
         $managerRegistry = static::getContainer()->get('doctrine');

--- a/tests/Functional/Security/Provider/SecurityUserFactoryTest.php
+++ b/tests/Functional/Security/Provider/SecurityUserFactoryTest.php
@@ -31,28 +31,28 @@ class SecurityUserFactoryTest extends KernelTestCase
     /**
      * @throws Throwable
      */
-    public function testThatLoadUserByUsernameThrowsAnExceptionWithInvalidUsername(): void
+    public function testThatLoadUserByIdentifierThrowsAnExceptionWithInvalidUsername(): void
     {
         $this->expectException(UserNotFoundException::class);
 
-        $this->getSecurityUserFactory()->loadUserByUsername('foobar');
+        $this->getSecurityUserFactory()->loadUserByIdentifier('foobar');
     }
 
     /**
-     * @dataProvider dataProviderTestThatLoadUserByUsernameReturnsExpectedUserInstance
+     * @dataProvider dataProviderTestThatLoadUserByIdentifierReturnsExpectedUserInstance
      *
      * @phpstan-param StringableArrayObject<array<int, string>> $roles
      * @psalm-param StringableArrayObject $roles
      *
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByUsername` method with `$username` input returns `SecurityUser` with `$roles` roles.
+     * @testdox Test that `loadUserByIdentifier` method with `$username` input returns `SecurityUser` with `$roles` roles.
      */
-    public function testThatLoadUserByUsernameReturnsExpectedUserInstance(
+    public function testThatLoadUserByIdentifierReturnsExpectedUserInstance(
         string $username,
         StringableArrayObject $roles
     ): void {
-        $domainUser = $this->getSecurityUserFactory()->loadUserByUsername($username);
+        $domainUser = $this->getSecurityUserFactory()->loadUserByIdentifier($username);
 
         static::assertInstanceOf(SecurityUser::class, $domainUser);
         static::assertSame($roles->getArrayCopy(), $domainUser->getRoles());
@@ -117,7 +117,7 @@ class SecurityUserFactoryTest extends KernelTestCase
     /**
      * @return Generator<array{0: string, 1: StringableArrayObject}>
      */
-    public function dataProviderTestThatLoadUserByUsernameReturnsExpectedUserInstance(): Generator
+    public function dataProviderTestThatLoadUserByIdentifierReturnsExpectedUserInstance(): Generator
     {
         yield ['john', new StringableArrayObject([])];
         yield ['john-api', new StringableArrayObject(['ROLE_API', 'ROLE_LOGGED'])];

--- a/tests/Functional/Security/Provider/SecurityUserFactoryTest.php
+++ b/tests/Functional/Security/Provider/SecurityUserFactoryTest.php
@@ -46,7 +46,7 @@ class SecurityUserFactoryTest extends KernelTestCase
      *
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByIdentifier` method with `$username` input returns `SecurityUser` with `$roles` roles.
+     * @testdox Test that `loadUserByIdentifier` method with `$username` returns `SecurityUser` with `$roles` roles
      */
     public function testThatLoadUserByIdentifierReturnsExpectedUserInstance(
         string $username,

--- a/tests/Integration/EventSubscriber/AuthenticationFailureSubscriberTest.php
+++ b/tests/Integration/EventSubscriber/AuthenticationFailureSubscriberTest.php
@@ -49,7 +49,7 @@ class AuthenticationFailureSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with('test-user')
             ->willReturn($user);
 
@@ -83,7 +83,7 @@ class AuthenticationFailureSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with('test-user')
             ->willReturn(null);
 

--- a/tests/Integration/EventSubscriber/AuthenticationSuccessSubscriberTest.php
+++ b/tests/Integration/EventSubscriber/AuthenticationSuccessSubscriberTest.php
@@ -50,7 +50,7 @@ class AuthenticationSuccessSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with($userEntity->getId())
             ->willReturn($userEntity);
 

--- a/tests/Integration/EventSubscriber/LockedUserSubscriberTest.php
+++ b/tests/Integration/EventSubscriber/LockedUserSubscriberTest.php
@@ -85,7 +85,7 @@ class LockedUserSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with($user->getId())
             ->willReturn($user);
 
@@ -109,7 +109,7 @@ class LockedUserSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with($user->getId())
             ->willReturn($user);
 
@@ -169,7 +169,7 @@ class LockedUserSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with('test-user')
             ->willReturn(null);
 
@@ -203,7 +203,7 @@ class LockedUserSubscriberTest extends KernelTestCase
 
         $userRepository
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with('test-user')
             ->willReturn(new UserEntity());
 

--- a/tests/Integration/Security/Provider/ApiKeyUserProviderTest.php
+++ b/tests/Integration/Security/Provider/ApiKeyUserProviderTest.php
@@ -84,9 +84,9 @@ class ApiKeyUserProviderTest extends KernelTestCase
     /**
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByUsername` method throws an exception when API key is not found
+     * @testdox Test that `loadUserByIdentifier` method throws an exception when API key is not found
      */
-    public function testThatLoadUserByUsernameThrowsAnException(): void
+    public function testThatLoadUserByIdentifierThrowsAnException(): void
     {
         $this->expectException(UserNotFoundException::class);
         $this->expectExceptionMessage('API key is not valid');
@@ -98,15 +98,15 @@ class ApiKeyUserProviderTest extends KernelTestCase
             ->willReturn(null);
 
         (new ApiKeyUserProvider($this->getApiKeyRepository(), $this->getRolesService()))
-            ->loadUserByUsername('guid');
+            ->loadUserByIdentifier('guid');
     }
 
     /**
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByUsername` method returns expected `ApiKeyUser` instance
+     * @testdox Test that `loadUserByIdentifier` method returns expected `ApiKeyUser` instance
      */
-    public function testThatLoadUserByUsernameCreatesExpectedApiKeyUser(): void
+    public function testThatLoadUserByIdentifierCreatesExpectedApiKeyUser(): void
     {
         $apiKey = new ApiKey();
 
@@ -117,7 +117,7 @@ class ApiKeyUserProviderTest extends KernelTestCase
             ->willReturn($apiKey);
 
         $user = (new ApiKeyUserProvider($this->getApiKeyRepository(), $this->getRolesService()))
-            ->loadUserByUsername('guid');
+            ->loadUserByIdentifier('guid');
 
         static::assertSame($apiKey, $user->getApiKey());
     }

--- a/tests/Integration/Security/Provider/SecurityUserFactoryTest.php
+++ b/tests/Integration/Security/Provider/SecurityUserFactoryTest.php
@@ -53,27 +53,27 @@ class SecurityUserFactoryTest extends KernelTestCase
     /**
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByUsername` method throws an exception when user is not found
+     * @testdox Test that `loadUserByIdentifier` method throws an exception when user is not found
      */
-    public function testThatLoadUserByUsernameThrowsAnExceptionIfUserNotFound(): void
+    public function testThatLoadUserByIdentifierThrowsAnExceptionIfUserNotFound(): void
     {
         $this->expectException(UserNotFoundException::class);
         $this->expectExceptionMessage('User not found for UUID:');
 
         $this->getUserRepositoryMock()
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with('test_user')
             ->willReturn(null);
 
         (new SecurityUserFactory($this->getUserRepository(), $this->getRolesService(), ''))
-            ->loadUserByUsername('test_user');
+            ->loadUserByIdentifier('test_user');
     }
 
     /**
      * @throws Throwable
      *
-     * @testdox Test that `loadUserByUsername` method returns expected `SecurityUser` instance
+     * @testdox Test that `loadUserByIdentifier` method returns expected `SecurityUser` instance
      */
     public function testThatLoadByUsernameReturnsExpectedSecurityUser(): void
     {
@@ -81,7 +81,7 @@ class SecurityUserFactoryTest extends KernelTestCase
 
         $this->getUserRepositoryMock()
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with('test_user')
             ->willReturn($user);
 
@@ -92,7 +92,7 @@ class SecurityUserFactoryTest extends KernelTestCase
             ->willReturn(['FOO', 'BAR']);
 
         $securityUser = (new SecurityUserFactory($this->getUserRepository(), $this->getRolesService(), ''))
-            ->loadUserByUsername('test_user');
+            ->loadUserByIdentifier('test_user');
 
         static::assertSame($user->getId(), $securityUser->getUserIdentifier());
         static::assertSame(['FOO', 'BAR'], $securityUser->getRoles());

--- a/tests/Integration/Security/UserTypeIdentificationTest.php
+++ b/tests/Integration/Security/UserTypeIdentificationTest.php
@@ -123,7 +123,7 @@ class UserTypeIdentificationTest extends KernelTestCase
 
         $this->getUserRepositoryMock()
             ->expects(static::once())
-            ->method('loadUserByUsername')
+            ->method('loadUserByIdentifier')
             ->with($user->getId(), true)
             ->willReturn($user);
 


### PR DESCRIPTION
Note that there is clean up job when Symfony 6.0.0 is released.