### PR TITLE
Chore(env) - Remove `develop` mode from Xdebug configuration to speed up `dev` environment

### DIFF
--- a/docker/php/php-dev.ini
+++ b/docker/php/php-dev.ini
@@ -28,6 +28,6 @@ decorate_workers_output = no
 apc.serializer=igbinary
 
 ; Xdebug settings
-xdebug.mode = coverage,debug,develop
+xdebug.mode = coverage,debug
 xdebug.start_with_request = yes
 xdebug.client_host = 127.0.0.1


### PR DESCRIPTION
Use eg. following script (source https://www.hungred.com/useful-information/average-website-response-time-bash-script/):

```bash
#!/bin/bash
 
CURL="/usr/bin/curl"
echo -n "Please pass the url you want to measure: "
read url
URL="$url"
count=1;
total_connect=0
total_start=0 
total_time=0
    echo " Time_Connect Time_startTransfer Time_total ";
while [ $count -le 100 ]
do
    result=`$CURL -o /dev/null -s -w %{time_connect}:%{time_starttransfer}:%{time_total} $URL`
    echo $result;
 
    var=$(echo $result | awk -F":" '{print $1, $2, $3}')
    set -- $var
 
    total_connect=`echo "scale=2; $total_connect + $1"  | bc`;
    total_start=`echo "scale=2; $total_start + $2" | bc`;
    total_time=`echo "scale=2; $total_time + $3" | bc`;
    count=$((count+1))
done
echo "average time connect: `echo "scale=2; $total_connect/100" | bc`";
echo "average time start: `echo "scale=2; $total_start/100" | bc`";
echo "average time taken: `echo "scale=2; $total_time/100" | bc`";
```

And then just run that command and enter URL to check.

Before (http://localhost:8000):
```bash
average time connect: 0
average time start: .39
average time taken: .39
```

After (http://localhost:8000):
```bash
average time connect: 0
average time start: .19
average time taken: .19
```

So the end result is cutting like `~200ms` of each request - basically half of the time and all that because of silly configuration issue...