### PR TITLE
Feat - Move Doctrine data fixtures under `App\Tests` namespace

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,7 +33,6 @@ services:
     App\:
         resource: '../src/'
         exclude:
-            - '../src/DataFixtures/'
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/EventListener/'
@@ -81,8 +80,8 @@ when@test:
             <<: *_services_defaults
             public: true
 
-        App\DataFixtures\:
-            resource: '../src/DataFixtures/*'
+        App\Tests\DataFixtures\:
+            resource: '../tests/DataFixtures/*'
 
         App\Tests\E2E\Rest\src\:
             resource: '../tests/E2E/Rest/src/*'

--- a/src/Security/Interfaces/RolesServiceInterface.php
+++ b/src/Security/Interfaces/RolesServiceInterface.php
@@ -21,17 +21,21 @@ interface RolesServiceInterface
     /**
      * Getter method to return all roles in single dimensional array.
      *
-     * @return array<int, string>
+     * @return array<int, non-empty-string>
      */
     public function getRoles(): array;
 
     /**
      * Getter method for role label.
+     *
+     * @return non-empty-string
      */
     public function getRoleLabel(string $role): string;
 
     /**
      * Getter method for short role.
+     *
+     * @return non-empty-string
      */
     public function getShort(string $role): string;
 
@@ -40,7 +44,7 @@ interface RolesServiceInterface
      *
      * @param array<int, string> $roles
      *
-     * @return array<int, string>
+     * @return array<int, non-empty-string>
      */
     public function getInheritedRoles(array $roles): array;
 }

--- a/tests/DataFixtures/AppFixtures.php
+++ b/tests/DataFixtures/AppFixtures.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types = 1);
 /**
- * /src/DataFixtures/AppFixtures.php
+ * /tests/DataFixtures/AppFixtures.php
  *
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
 
-namespace App\DataFixtures;
+namespace App\Tests\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;

--- a/tests/DataFixtures/ORM/LoadApiKeyData.php
+++ b/tests/DataFixtures/ORM/LoadApiKeyData.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types = 1);
 /**
- * /src/DataFixtures/ORM/LoadApiKeyData.php
+ * /tests/DataFixtures/ORM/LoadApiKeyData.php
  *
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
 
-namespace App\DataFixtures\ORM;
+namespace App\Tests\DataFixtures\ORM;
 
 use App\Entity\ApiKey;
 use App\Entity\UserGroup;
@@ -22,7 +22,7 @@ use function array_map;
 use function str_pad;
 
 /**
- * @package App\DataFixtures\ORM
+ * @package App\Tests\DataFixtures\ORM
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  *
  * @psalm-suppress PropertyNotSetInConstructor

--- a/tests/DataFixtures/ORM/LoadApiKeyData.php
+++ b/tests/DataFixtures/ORM/LoadApiKeyData.php
@@ -30,7 +30,7 @@ use function str_pad;
 final class LoadApiKeyData extends Fixture implements OrderedFixtureInterface
 {
     /**
-     * @var array<string, string>
+     * @var array<string, non-empty-string>
      */
     private array $uuids = [
         '' => '30000000-0000-1000-8000-000000000001',
@@ -95,7 +95,7 @@ final class LoadApiKeyData extends Fixture implements OrderedFixtureInterface
         PhpUnitUtil::setProperty(
             'id',
             UuidHelper::fromString($this->uuids[$suffix]),
-            $entity
+            $entity,
         );
 
         // Persist entity

--- a/tests/DataFixtures/ORM/LoadRoleData.php
+++ b/tests/DataFixtures/ORM/LoadRoleData.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types = 1);
 /**
- * /src/DataFixtures/ORM/LoadRoleData.php
+ * /tests/DataFixtures/ORM/LoadRoleData.php
  *
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
 
-namespace App\DataFixtures\ORM;
+namespace App\Tests\DataFixtures\ORM;
 
 use App\Entity\Role;
 use App\Security\Interfaces\RolesServiceInterface;
@@ -18,7 +18,7 @@ use Throwable;
 use function array_map;
 
 /**
- * @package App\DataFixtures\ORM
+ * @package App\Tests\DataFixtures\ORM
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  *
  * @psalm-suppress PropertyNotSetInConstructor

--- a/tests/DataFixtures/ORM/LoadUserData.php
+++ b/tests/DataFixtures/ORM/LoadUserData.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types = 1);
 /**
- * /src/DataFixtures/ORM/LoadUserData.php
+ * /tests/DataFixtures/ORM/LoadUserData.php
  *
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
 
-namespace App\DataFixtures\ORM;
+namespace App\Tests\DataFixtures\ORM;
 
 use App\Entity\User;
 use App\Entity\UserGroup;
@@ -23,7 +23,7 @@ use Throwable;
 use function array_map;
 
 /**
- * @package App\DataFixtures\ORM
+ * @package App\Tests\DataFixtures\ORM
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  *
  * @psalm-suppress PropertyNotSetInConstructor

--- a/tests/DataFixtures/ORM/LoadUserData.php
+++ b/tests/DataFixtures/ORM/LoadUserData.php
@@ -31,7 +31,7 @@ use function array_map;
 final class LoadUserData extends Fixture implements OrderedFixtureInterface
 {
     /**
-     * @var array<string, string>
+     * @var array<non-empty-string, non-empty-string>
      */
     public static array $uuids = [
         'john' => '20000000-0000-1000-8000-000000000001',
@@ -101,7 +101,7 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
         PhpUnitUtil::setProperty(
             'id',
             UuidHelper::fromString(self::$uuids['john' . $suffix]),
-            $entity
+            $entity,
         );
 
         // Persist entity

--- a/tests/DataFixtures/ORM/LoadUserGroupData.php
+++ b/tests/DataFixtures/ORM/LoadUserGroupData.php
@@ -29,7 +29,7 @@ use function array_map;
 final class LoadUserGroupData extends Fixture implements OrderedFixtureInterface
 {
     /**
-     * @var array<string, string>
+     * @var array<non-empty-string, non-empty-string>
      */
     public static array $uuids = [
         'Role-logged' => '10000000-0000-1000-8000-000000000001',
@@ -74,14 +74,14 @@ final class LoadUserGroupData extends Fixture implements OrderedFixtureInterface
         $roleReference = $this->getReference('Role-' . $this->rolesService->getShort($role), Role::class);
 
         // Create new entity
-        $entity = new UserGroup();
-        $entity->setRole($roleReference);
-        $entity->setName($this->rolesService->getRoleLabel($role));
+        $entity = (new UserGroup())
+            ->setRole($roleReference)
+            ->setName($this->rolesService->getRoleLabel($role));
 
         PhpUnitUtil::setProperty(
             'id',
             UuidHelper::fromString(self::$uuids['Role-' . $this->rolesService->getShort($role)]),
-            $entity
+            $entity,
         );
 
         // Persist entity

--- a/tests/DataFixtures/ORM/LoadUserGroupData.php
+++ b/tests/DataFixtures/ORM/LoadUserGroupData.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types = 1);
 /**
- * /src/DataFixtures/ORM/LoadUserGroupData.php
+ * /tests/DataFixtures/ORM/LoadUserGroupData.php
  *
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  */
 
-namespace App\DataFixtures\ORM;
+namespace App\Tests\DataFixtures\ORM;
 
 use App\Entity\Role;
 use App\Entity\UserGroup;
@@ -21,7 +21,7 @@ use Throwable;
 use function array_map;
 
 /**
- * @package App\DataFixtures\ORM
+ * @package App\Tests\DataFixtures\ORM
  * @author TLe, Tarmo Leppänen <tarmo.leppanen@pinja.com>
  *
  * @psalm-suppress PropertyNotSetInConstructor

--- a/tests/E2E/Controller/v1/User/AttachUserGroupControllerTest.php
+++ b/tests/E2E/Controller/v1/User/AttachUserGroupControllerTest.php
@@ -8,8 +8,8 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\User;
 
-use App\DataFixtures\ORM\LoadUserData;
-use App\DataFixtures\ORM\LoadUserGroupData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserGroupData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Tests\Utils\PhpUnitUtil;
 use App\Utils\JSON;

--- a/tests/E2E/Controller/v1/User/DeleteUserControllerTest.php
+++ b/tests/E2E/Controller/v1/User/DeleteUserControllerTest.php
@@ -8,7 +8,7 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\User;
 
-use App\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Tests\Utils\PhpUnitUtil;
 use Generator;

--- a/tests/E2E/Controller/v1/User/DetachUserGroupControllerTest.php
+++ b/tests/E2E/Controller/v1/User/DetachUserGroupControllerTest.php
@@ -8,8 +8,8 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\User;
 
-use App\DataFixtures\ORM\LoadUserData;
-use App\DataFixtures\ORM\LoadUserGroupData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserGroupData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Tests\Utils\PhpUnitUtil;
 use Generator;

--- a/tests/E2E/Controller/v1/User/UserGroupsControllerTest.php
+++ b/tests/E2E/Controller/v1/User/UserGroupsControllerTest.php
@@ -8,7 +8,7 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\User;
 
-use App\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Tests\Utils\StringableArrayObject;
 use App\Utils\JSON;

--- a/tests/E2E/Controller/v1/User/UserRolesControllerTest.php
+++ b/tests/E2E/Controller/v1/User/UserRolesControllerTest.php
@@ -8,9 +8,9 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\User;
 
-use App\DataFixtures\ORM\LoadUserData;
 use App\Enum\Role;
 use App\Security\Interfaces\RolesServiceInterface;
+use App\Tests\DataFixtures\ORM\LoadUserData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Utils\JSON;
 use Generator;

--- a/tests/E2E/Controller/v1/User/UserUpdateInvalidUserTest.php
+++ b/tests/E2E/Controller/v1/User/UserUpdateInvalidUserTest.php
@@ -8,7 +8,7 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\User;
 
-use App\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Utils\JSON;
 use Generator;

--- a/tests/E2E/Controller/v1/UserGroup/AttachUserControllerTest.php
+++ b/tests/E2E/Controller/v1/UserGroup/AttachUserControllerTest.php
@@ -8,8 +8,8 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\UserGroup;
 
-use App\DataFixtures\ORM\LoadUserData;
-use App\DataFixtures\ORM\LoadUserGroupData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserGroupData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Tests\Utils\PhpUnitUtil;
 use App\Utils\JSON;

--- a/tests/E2E/Controller/v1/UserGroup/DetachUserControllerTest.php
+++ b/tests/E2E/Controller/v1/UserGroup/DetachUserControllerTest.php
@@ -8,8 +8,8 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\UserGroup;
 
-use App\DataFixtures\ORM\LoadUserData;
-use App\DataFixtures\ORM\LoadUserGroupData;
+use App\Tests\DataFixtures\ORM\LoadUserData;
+use App\Tests\DataFixtures\ORM\LoadUserGroupData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Tests\Utils\PhpUnitUtil;
 use Generator;

--- a/tests/E2E/Controller/v1/UserGroup/UsersControllerTest.php
+++ b/tests/E2E/Controller/v1/UserGroup/UsersControllerTest.php
@@ -8,7 +8,7 @@ declare(strict_types = 1);
 
 namespace App\Tests\E2E\Controller\v1\UserGroup;
 
-use App\DataFixtures\ORM\LoadUserGroupData;
+use App\Tests\DataFixtures\ORM\LoadUserGroupData;
 use App\Tests\E2E\TestCase\WebTestCase;
 use App\Utils\JSON;
 use Generator;


### PR DESCRIPTION
Fixtures are only used within tests, so we don't need those in actual `prod` container.